### PR TITLE
Fix duplicate images

### DIFF
--- a/app/controllers/admin/properties_controller.rb
+++ b/app/controllers/admin/properties_controller.rb
@@ -44,15 +44,16 @@ class Admin::PropertiesController < Admin::BaseController
 
   def update
     # Separar imagens dos outros parâmetros
-    images = property_params.delete(:images)
+    attrs = property_params
+    images = attrs.delete(:images)
     
     Rails.logger.debug "=== DEBUG UPDATE PROPERTY ==="
-    Rails.logger.debug "Property params (sem imagens): #{property_params.inspect}"
+    Rails.logger.debug "Property params (sem imagens): #{attrs.inspect}"
     Rails.logger.debug "Novas imagens: #{images&.length || 0} arquivos"
 
     
     # Atualizar campos normais (sem imagens)
-    if @property.update(property_params)
+    if @property.update(attrs)
       # Anexar novas imagens (se houver) SEM remover as existentes
       if images.present?
         @property.images.attach(images)


### PR DESCRIPTION
## Summary
- prevent duplicated images when updating properties

## Testing
- `bundle exec rubocop` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae992058c832786cc43196886ee2f